### PR TITLE
fixed an issue where the locale affects the handling of floats

### DIFF
--- a/src/Number/Real.php
+++ b/src/Number/Real.php
@@ -45,7 +45,6 @@ class Real implements ValueObjectInterface, NumberInterface
         # Only apply the decimal-point character fix if needed, otherwise preserve the old value
         if ($stringValue !== (string)$value) {
             $value = \filter_var($stringValue, FILTER_VALIDATE_FLOAT);
-
         } else {
             $value = \filter_var($value, FILTER_VALIDATE_FLOAT);
         }

--- a/src/Number/Real.php
+++ b/src/Number/Real.php
@@ -35,7 +35,20 @@ class Real implements ValueObjectInterface, NumberInterface
      */
     public function __construct($value)
     {
-        $value = \filter_var($value, FILTER_VALIDATE_FLOAT);
+        /** @var string $stringValue */
+        $stringValue = (string)$value;
+
+        # In some locales the decimal-point character might be different,
+        # which can cause filter_var($value, FILTER_VALIDATE_FLOAT) to fail.
+        $stringValue = str_replace(',', '.', $stringValue);
+
+        # Only apply the decimal-point character fix if needed, otherwise preserve the old value
+        if ($stringValue !== (string)$value) {
+            $value = \filter_var($stringValue, FILTER_VALIDATE_FLOAT);
+
+        } else {
+            $value = \filter_var($value, FILTER_VALIDATE_FLOAT);
+        }
 
         if (false === $value) {
             throw new InvalidNativeArgumentException($value, ['float']);

--- a/tests/Climate/CelsiusTest.php
+++ b/tests/Climate/CelsiusTest.php
@@ -8,6 +8,13 @@ use PHPUnit\Framework\TestCase;
 
 class CelsiusTest extends TestCase
 {
+    public function setUp()
+    {
+        # When tests run in a different locale, this might affect the decimal-point character and thus the validation
+        # of floats. This makes sure the tests run in a locale that the tests are known to be working in.
+        setlocale(LC_ALL, "en_US.UTF-8");
+    }
+
     public function temperatureProvider()
     {
         return array(array(new Celsius(10)));
@@ -35,5 +42,17 @@ class CelsiusTest extends TestCase
     public function testToFahrenheit(Celsius $temperature)
     {
         $this->assertEquals(10 * 1.8 + 32, $temperature->toFahrenheit()->toNative());
+    }
+
+    /**
+     * @dataProvider temperatureProvider
+     */
+    public function testDifferentLocaleWithDifferentDecimalCharacter(Celsius $temperature)
+    {
+        setlocale(LC_ALL, "de_DE.UTF-8");
+
+        $this->testToCelsius($temperature);
+        $this->testToKelvin($temperature);
+        $this->testToFahrenheit($temperature);
     }
 }

--- a/tests/Climate/FahrenheitTest.php
+++ b/tests/Climate/FahrenheitTest.php
@@ -6,6 +6,13 @@ use PHPUnit\Framework\TestCase;
 
 class FahrenheitTest extends TestCase
 {
+    public function setUp()
+    {
+        # When tests run in a different locale, this might affect the decimal-point character and thus the validation
+        # of floats. This makes sure the tests run in a locale that the tests are known to be working in.
+        setlocale(LC_ALL, "en_US.UTF-8");
+    }
+
     public function temperatureProvider()
     {
         return array(array(new Fahrenheit(10)));
@@ -36,5 +43,17 @@ class FahrenheitTest extends TestCase
     public function testToFahrenheit(Fahrenheit $temperature)
     {
         $this->assertEquals(10, $temperature->toFahrenheit()->toNative());
+    }
+
+    /**
+     * @dataProvider temperatureProvider
+     */
+    public function testDifferentLocaleWithDifferentDecimalCharacter(Fahrenheit $temperature)
+    {
+        setlocale(LC_ALL, "de_DE.UTF-8");
+
+        $this->testToCelsius($temperature);
+        $this->testToKelvin($temperature);
+        $this->testToFahrenheit($temperature);
     }
 }

--- a/tests/Climate/KelvinTest.php
+++ b/tests/Climate/KelvinTest.php
@@ -6,6 +6,13 @@ use PHPUnit\Framework\TestCase;
 
 class KelvinTest extends TestCase
 {
+    public function setUp()
+    {
+        # When tests run in a different locale, this might affect the decimal-point character and thus the validation
+        # of floats. This makes sure the tests run in a locale that the tests are known to be working in.
+        setlocale(LC_ALL, "en_US.UTF-8");
+    }
+
     public function temperatureProvider()
     {
         return array(array(new Kelvin(10)));
@@ -33,5 +40,17 @@ class KelvinTest extends TestCase
     public function testToFahrenheit(Kelvin $temperature)
     {
         $this->assertEquals($temperature->toCelsius()->toNative() * 1.8 + 32, $temperature->toFahrenheit()->toNative());
+    }
+
+    /**
+     * @dataProvider temperatureProvider
+     */
+    public function testDifferentLocaleWithDifferentDecimalCharacter(Kelvin $temperature)
+    {
+        setlocale(LC_ALL, "de_DE.UTF-8");
+
+        $this->testToCelsius($temperature);
+        $this->testToKelvin($temperature);
+        $this->testToFahrenheit($temperature);
     }
 }

--- a/tests/Geography/CoordinateTest.php
+++ b/tests/Geography/CoordinateTest.php
@@ -17,6 +17,10 @@ class CoordinateTest extends TestCase
 
     public function setup()
     {
+        # When tests run in a different locale, this might affect the decimal-point character and thus the validation
+        # of floats. This makes sure the tests run in a locale that the tests are known to be working in.
+        setlocale(LC_ALL, "en_US.UTF-8");
+
         $this->coordinate = new Coordinate(
             new Latitude(40.829137),
             new Longitude(16.555838)
@@ -114,5 +118,25 @@ class CoordinateTest extends TestCase
     public function testToString()
     {
         $this->assertSame('40.829137,16.555838', $this->coordinate->__toString());
+    }
+
+    public function testDifferentLocaleWithDifferentDecimalCharacter()
+    {
+        setlocale(LC_ALL, "de_DE.UTF-8");
+
+        $this->testNullConstructorEllipsoid();
+        $this->testFromNative();
+        $this->testSameValueAs();
+        $this->getLatitude();
+        $this->getLongitude();
+        $this->getEllipsoid();
+        $this->testToUniversalTransverseMercator();
+        $this->testDistanceFrom();
+        $this->testToString();
+
+        # TODO: The following two tests break because of faults in another library and should be fixed there.
+        #       (vendor/league/geotools/src/Convert/Convert.php:53 | A non well formed numeric value encountered)
+        #$this->testToDegreesMinutesSeconds();
+        #$this->testToDecimalMinutes();
     }
 }

--- a/tests/Money/MoneyTest.php
+++ b/tests/Money/MoneyTest.php
@@ -12,6 +12,13 @@ use ValueObjects\ValueObjectInterface;
 
 class MoneyTest extends TestCase
 {
+    public function setUp()
+    {
+        # When tests run in a different locale, this might affect the decimal-point character and thus the validation
+        # of floats. This makes sure the tests run in a locale that the tests are known to be working in.
+        setlocale(LC_ALL, "en_US.UTF-8");
+    }
+
     public function testFromNative()
     {
         $fromNativeMoney = Money::fromNative(2100, 'EUR');
@@ -108,5 +115,20 @@ class MoneyTest extends TestCase
         $money = new Money(new Integer(1200), $eur);
 
         $this->assertSame('EUR 1200', $money->__toString());
+    }
+
+    public function testDifferentLocaleWithDifferentDecimalCharacter()
+    {
+        setlocale(LC_ALL, "de_DE.UTF-8");
+
+        $this->testFromNative();
+        $this->testSameValueAs();
+        $this->testGetAmount();
+        $this->testGetCurrency();
+        $this->testAdd();
+        $this->testAddNegative();
+        $this->testMultiply();
+        $this->testMultiplyInverse();
+        $this->testToString();
     }
 }

--- a/tests/Number/ComplexTest.php
+++ b/tests/Number/ComplexTest.php
@@ -13,6 +13,10 @@ class ComplexTest extends TestCase
 
     public function setup()
     {
+        # When tests run in a different locale, this might affect the decimal-point character and thus the validation
+        # of floats. This makes sure the tests run in a locale that the tests are known to be working in.
+        setlocale(LC_ALL, "en_US.UTF-8");
+
         $this->complex = new Complex(new Real(2.05), new Real(3.2));
     }
 
@@ -77,14 +81,29 @@ class ComplexTest extends TestCase
         $this->assertTrue($arg->sameValueAs($this->complex->getArgument()));
     }
 
-    public function testToString()
+    public function testToString($expectedString = '2.034 - 1.4i')
     {
         $complex = new Complex(new Real(2.034), new Real(-1.4));
-        $this->assertEquals('2.034 - 1.4i', $complex->__toString());
+        $this->assertEquals($expectedString, $complex->__toString());
     }
 
     public function testNotSameValue()
     {
         $this->assertFalse($this->complex->sameValueAs(new Real(2.035)));
+    }
+
+    public function testDifferentLocaleWithDifferentDecimalCharacter()
+    {
+        setlocale(LC_ALL, "de_DE.UTF-8");
+
+        $this->testFromNative();
+        $this->testFromPolar();
+        $this->testToNative();
+        $this->testGetReal();
+        $this->testGetIm();
+        $this->testGetModulus();
+        $this->testGetArgument();
+        $this->testToString('2,034 - 1,4i');
+        $this->testNotSameValue();
     }
 }

--- a/tests/Number/RealTest.php
+++ b/tests/Number/RealTest.php
@@ -10,6 +10,13 @@ use ValueObjects\ValueObjectInterface;
 
 class RealTest extends TestCase
 {
+    public function setUp()
+    {
+        # When tests run in a different locale, this might affect the decimal-point character and thus the validation
+        # of floats. This makes sure the tests run in a locale that the tests are known to be working in.
+        setlocale(LC_ALL, "en_US.UTF-8");
+    }
+
     public function testFromNative()
     {
         $fromNativeReal  = Real::fromNative(.056);
@@ -63,9 +70,21 @@ class RealTest extends TestCase
         $this->assertTrue($natural->sameValueAs($nativeNatural));
     }
 
-    public function testToString()
+    public function testToString($expectedString = '.7')
     {
         $real = new Real(.7);
-        $this->assertEquals('.7', $real->__toString());
+        $this->assertEquals($expectedString, $real->__toString());
+    }
+
+    public function testDifferentLocaleWithDifferentDecimalCharacter()
+    {
+        setlocale(LC_ALL, "de_DE.UTF-8");
+
+        $this->testFromNative();
+        $this->testToNative();
+        $this->testSameValueAs();
+        $this->testToInteger();
+        $this->testToNatural();
+        $this->testToString('0,7');
     }
 }


### PR DESCRIPTION
This is a possible fix for issue #5. It changes the handling of float values in the Real class to support float values in a locale with a different decimal-point character.

I have also added some tests that make sure that the float-handling work in both the en-us locale and the de-de locale (where the decimal-point charachter is ',').

I don't know if this is the optimal way of handling the problem. I have tried to write the code in a way that it should produce expected results for the the most possible cases, which may have resulted in a bit too complex code. What do you think?