### PR TITLE
Corrected a few type-hints

### DIFF
--- a/src/Money/Money.php
+++ b/src/Money/Money.php
@@ -38,7 +38,7 @@ class Money implements ValueObjectInterface
     /**
      * Returns a Money object.
      *
-     * @param int      $amount   Amount expressed in the smallest units of $currency (e.g. cents)
+     * @param Integer  $amount   Amount expressed in the smallest units of $currency (e.g. cents)
      * @param Currency $currency Currency of the money object
      */
     public function __construct(Integer $amount, Currency $currency)

--- a/src/Number/Integer.php
+++ b/src/Number/Integer.php
@@ -69,7 +69,7 @@ class Integer extends Real
     /**
      * Returns a Real with the value of the Integer.
      *
-     * @return float
+     * @return Real
      */
     public function toReal(): Real
     {

--- a/src/Number/Real.php
+++ b/src/Number/Real.php
@@ -99,7 +99,7 @@ class Real implements ValueObjectInterface, NumberInterface
      *
      * @param RoundingMode $roundingMode Rounding mode of the conversion. Defaults to RoundingMode::HALF_UP.
      *
-     * @return int
+     * @return Integer
      */
     public function toInteger(RoundingMode $roundingMode = null): Integer
     {


### PR DESCRIPTION
There are a few incorrect (return- and argument-) types defined in doc-blocks that differ from the actual PHP native types and thus cause problems for static analysis (psalm in my case). This PR should fix these issues.
There might be more such wrong types, I have only now corrected the few types that were offending in my case.

```
ERROR: InvalidMethodCall - php/Foo/Bar/Baz.php:123:456 - Cannot call method on float variable  (see https://psalm.dev/091)
            $this->chargeAmount->getAmount()->toReal()->toNative(),
```

```
ERROR: InvalidArgument - php/Foo/Bar/Baz.php:123:456 - Argument 1 of ValueObjects\Money\Money::__construct expects int, ValueObjects\Number\Integer provided (see https://psalm.dev/004)
            $lowestMoney = new Money(new Integer((int)$lowestPrice), new Currency($this->catalog->getCurrencyCode()));
```